### PR TITLE
chore: update major tag

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,6 +5,7 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/changelog", {"changelogTitle": "# Changelog"}],
+    "semantic-release-major-tag",
     ["@semantic-release/github", {
       "failComment": false,
       "failTitle": false,

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "eslint": "8.36.0",
     "eslint-config-molindo": "6.0.0",
     "jest": "29.5.0",
-    "semantic-release": "^19.0.5"
+    "semantic-release": "^19.0.5",
+    "semantic-release-major-tag": "0.3.2"
   },
   "engines": {
     "node": "^20.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,6 +6149,11 @@ safe-regex@^2.1.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+semantic-release-major-tag@0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/semantic-release-major-tag/-/semantic-release-major-tag-0.3.2.tgz#9ea6b7139721fa58e8a76382adafe165d56a4b90"
+  integrity sha512-XTB3mVG6D6oPHSW/zhWC3eSoBRiLqZjKtjTc90wcLzS0DG00UORnn7CceDGdYc5dIl0BG91eO873HvECimyE+Q==
+
 semantic-release@^19.0.5:
   version "19.0.5"
   resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-19.0.5.tgz#d7fab4b33fc20f1288eafd6c441e5d0938e5e174"


### PR DESCRIPTION
<!--

Thank you very much for contributing to this project!

Please make sure to have a look at the [contributors guide](https://github.com/amannn/action-semantic-pull-request/blob/master/CONTRIBUTORS.md) so you can test your changes.

For any non-trivial changes, please include a link to a workflow where you've tested the current state of this pull request (see contributors guide).

-->

Adds the `semantic-release` plugin [`semantic-release-major-tag`](https://github.com/doteric/semantic-release-major-tag) which also tags the release commit with the major release, e.g. `v5`.

Currently, the [`v5` major version tag](https://github.com/amannn/action-semantic-pull-request/tree/v5) is tagged to the release commit for `v5.4.0`. So, if a Github workflow refers to the action using just the major version: `amannn/action-semantic-pull-request@v5` it will not use the latest release.


